### PR TITLE
Update libsToInject.js to solve an exception

### DIFF
--- a/src/js/libsToInject.js
+++ b/src/js/libsToInject.js
@@ -117,7 +117,7 @@ var libsToInject = {
             for (a in e) d = e[a], B.headers[a] || (c = a.toLowerCase(), B.headers[c] = d)
           }
         }, w = function() {
-          "responseText" in H && (B.text = H.responseText), "responseXML" in H && (B.xml = H.responseXML), "response" in H && (B.data = H.response)
+          "responseText" in H && H.responseType != 'json' && (B.text = H.responseText), "responseXML" in H && H.responseType != 'json' && (B.xml = H.responseXML), "response" in H && (B.data = H.response)
         }, G = function() {
           q.status = B.status, q.statusText = B.statusText
         }, F = function() {


### PR DESCRIPTION
This small change solves an exception I got when working with json requests. The H.responseText contains an error when the responseType is not like text or '' as the exception said.